### PR TITLE
Ignore certification validation for WinRM

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -834,7 +834,7 @@ def wait_for_winrm(host, port, username, password, timeout=900):
     while True:
         trycount += 1
         try:
-            s = winrm.Session(host, auth=(username, password), transport='ssl')
+            s = winrm.Session(host, auth=(username, password), transport='ssl', server_cert_validation='ignore')
             if hasattr(s.protocol, 'set_timeout'):
                 s.protocol.set_timeout(15)
             log.trace('WinRM endpoint url: {0}'.format(s.url))


### PR DESCRIPTION
What does this PR do?
Ignore the certification validation when making an SSL connection with WinRM during cloud deployments.

What issues does this PR fix or reference?
https://github.com/saltstack/salt/issues/34783

Previous Behavior
When using version 0.2.0 of pywinrm the bootstrap will fail since it receives an invalid certificate error. This is caused due to a self-signed certificate being used and the python requests URLLib3 library can't verify the certificate.

New Behavior
The certificate validation will be ignored and will allow the bootstrap to continue.

NOTE:
One other workaround was to revert back to pywinrm 0.1.1 but investigation as to why that was working revealed it allows ignored certificate validation regardless of what you configured it for.

Tests written?
No

https://github.com/saltstack/salt/issues/34783
